### PR TITLE
fix: copy-style-files.ts

### DIFF
--- a/src/build/copy-style-files.ts
+++ b/src/build/copy-style-files.ts
@@ -9,12 +9,14 @@ export const copyStyleFiles = () => {
       if (err) return reject(err)
       files.forEach((filename) => {
         const filepath = path.resolve(cwd, filename)
-        const distPathEs = filepath
+        const distNameEs = filename
           .replace(/src\//, 'esm/')
           .replace(/src\\/, 'esm\\')
-        const distPathLib = filepath
+        const distNameLib = filename
           .replace(/src\//, 'lib/')
           .replace(/src\\/, 'lib\\')
+        const distPathEs = path.resolve(cwd, distNameEs)
+        const distPathLib = path.resolve(cwd, distNameLib)
         fs.copySync(filepath, distPathEs)
         fs.copySync(filepath, distPathLib)
       })


### PR DESCRIPTION
修复当项目全路径含src时,编译产生的样式文件的路径不符合预期的问题

fix #7