### PR TITLE
fix: node > 17 Error loading tslib helper library

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup-plugin-typescript2": "^0.31.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.5"
   },


### PR DESCRIPTION
fix: node v17: Error loading tslib helper library

详见：https://github.com/ezolenko/rollup-plugin-typescript2/issues/286